### PR TITLE
Add `par` function for parallel applicative-style composition of promises.

### DIFF
--- a/src/thx/promise/Future.hx
+++ b/src/thx/promise/Future.hx
@@ -94,7 +94,7 @@ class Future<T> {
   inline public function mapFuture<TOut>(handler : T -> Future<TOut>) : Future<TOut>
     return flatMap(map(handler));
 
-  public function then(handler : T -> Void) {
+  public function then(handler : T -> Void): Future<T> {
     handlers.push(handler);
     update();
     return this;

--- a/src/thx/promise/Promise.hx
+++ b/src/thx/promise/Promise.hx
@@ -181,7 +181,7 @@ abstract Promise<T>(Future<Result<T, Error>>) from Future<Result<T, Error>> to F
     );
 
   @:deprecated("mapSuccess is deprecated. Use map instead")
-  public function mapSuccess<TOut>(success : T -> TOut) : Promise<TOut>
+  inline public function mapSuccess<TOut>(success : T -> TOut) : Promise<TOut>
     return map(success);
 
   inline public function flatMap<TOut>(success : T -> Promise<TOut>) : Promise<TOut>
@@ -429,9 +429,7 @@ class PromiseNil {
     });
 
   public static function nil(p : Promise<Dynamic>) : Promise<Nil>
-    return Promise.create(function(resolve : Nil -> Void, reject)
-      p.success(function(_) resolve(Nil.nil))
-       .failure(reject));
+    return p.map(const(Nil.nil));
 }
 
 #if js

--- a/src/thx/promise/Promise.hx
+++ b/src/thx/promise/Promise.hx
@@ -2,6 +2,7 @@ package thx.promise;
 
 import haxe.ds.Option;
 import thx.Error;
+import thx.fp.Functions.const;
 import thx.Tuple;
 import thx.Nil;
 using thx.Options;
@@ -11,7 +12,7 @@ import thx.Either;
 
 typedef PromiseValue<T> = Result<T, Error>;
 
-@:forward(hasValue, map, mapAsync, mapFuture, state, then)
+@:forward(hasValue, mapAsync, mapFuture, state, then)
 abstract Promise<T>(Future<Result<T, Error>>) from Future<Result<T, Error>> to Future<Result<T, Error>> {
   @:from public static function futureToPromise<T>(future : Future<T>) : Promise<T>
     return future.map(function(v) return (Right(v) : PromiseValue<T>));
@@ -26,7 +27,7 @@ abstract Promise<T>(Future<Result<T, Error>>) from Future<Result<T, Error>> to F
             resolve(nil);
           } else {
             arr.shift()
-              .mapSuccess(poll)
+              .map(poll)
               .mapFailure(reject);
           }
         }
@@ -171,21 +172,41 @@ abstract Promise<T>(Future<Result<T, Error>>) from Future<Result<T, Error>> to F
   public function mapFailurePromise(failure : Error -> Promise<T>) : Promise<T>
     return mapEitherFuture(function(value) return Promise.value(value), failure);
 
-  public function mapSuccess<TOut>(success : T -> TOut) : Promise<TOut>
+  public function map<U>(success : T -> U) : Promise<U>
     return mapEitherFuture(
-      function(v)   return
+      function(v) return
         try Promise.value(success(v))
         catch(e : Dynamic) Promise.error(Error.fromDynamic(e)),
-      function(err) return Promise.error(err));
+      function(err) return Promise.error(err)
+    );
+
+  @:deprecated("mapSuccess is deprecated. Use map instead")
+  public function mapSuccess<TOut>(success : T -> TOut) : Promise<TOut>
+    return map(success);
 
   inline public function flatMap<TOut>(success : T -> Promise<TOut>) : Promise<TOut>
-    return mapSuccessPromise(success);
-
-  public function mapSuccessPromise<TOut>(success : T -> Promise<TOut>) : Promise<TOut>
     return mapEitherFuture(success, function(err) return Promise.error(err));
 
+  @:op(A >> B)
+  inline public function andTnen<B>(next: Void -> Promise<B>): Promise<B>
+    return flatMap(function(_) return next());
+
+  /**
+   * Performs an additional effect with the result of this promise, and
+   * when it completes ignore the resulting value and instead return 
+   * the result of this promise. This is similar to success(...) 
+   * except that the additional side effect expressed in the result of `f`
+   * must complete before computation can proceed. 
+   */
+  inline public function foreachM<U>(f: T -> Promise<U>): Promise<T>
+    return flatMap(function(t) return f(t).map(const(t)));
+
+  @:deprecated("mapSuccessPromise is deprecated. Use flatMap instead")
+  public function mapSuccessPromise<TOut>(success : T -> Promise<TOut>) : Promise<TOut>
+    return flatMap(success);
+
   public function mapNull(handler : Void -> Promise<Null<T>>) : Promise<T>
-    return mapSuccessPromise(function(v : Null<T>) {
+    return flatMap(function(v : Null<T>) {
       if(null == v)
         return handler();
       else
@@ -243,25 +264,25 @@ class Promises {
 
   public static function join3<T1, T2, T3>(p1 : Promise<T1>, p2 : Promise<T2>, p3 : Promise<T3>) : Promise<Tuple3<T1, T2, T3>>
     return join(join(p1, p2), p3)
-      .mapSuccess(function(values) {
+      .map(function(values) {
         return new Tuple3(values._0._0, values._0._1, values._1);
       });
 
   public static function join4<T1, T2, T3, T4>(p1 : Promise<T1>, p2 : Promise<T2>, p3 : Promise<T3>, p4 : Promise<T4>) : Promise<Tuple4<T1, T2, T3, T4>>
     return join(join3(p1, p2, p3), p4)
-      .mapSuccess(function(values) {
+      .map(function(values) {
         return new Tuple4(values._0._0, values._0._1, values._0._2, values._1);
       });
 
   public static function join5<T1, T2, T3, T4, T5>(p1 : Promise<T1>, p2 : Promise<T2>, p3 : Promise<T3>, p4 : Promise<T4>, p5 : Promise<T5>) : Promise<Tuple5<T1, T2, T3, T4, T5>>
     return join(join4(p1, p2, p3, p4), p5)
-      .mapSuccess(function(values) {
+      .map(function(values) {
         return new Tuple5(values._0._0, values._0._1, values._0._2, values._0._3, values._1);
       });
 
   public static function join6<T1, T2, T3, T4, T5, T6>(p1 : Promise<T1>, p2 : Promise<T2>, p3 : Promise<T3>, p4 : Promise<T4>, p5 : Promise<T5>, p6 : Promise<T6>) : Promise<Tuple6<T1, T2, T3, T4, T5, T6>>
     return join(join5(p1, p2, p3, p4, p5), p6)
-      .mapSuccess(function(values) {
+      .map(function(values) {
         return new Tuple6(values._0._0, values._0._1, values._0._2, values._0._3, values._0._4, values._1);
       });
 
@@ -274,12 +295,12 @@ class Promises {
 
 class PromiseTuple6 {
   public static function mapTuplePromise<T1,T2,T3,T4,T5,T6,TOut>(promise : Promise<Tuple6<T1,T2,T3,T4,T5,T6>>, success : T1 -> T2 -> T3 -> T4 -> T5 -> T6 -> Promise<TOut>) : Promise<TOut>
-    return promise.mapSuccessPromise(function(t)
+    return promise.flatMap(function(t)
       return success(t._0, t._1, t._2, t._3, t._4, t._5)
     );
 
   public static function mapTuple<T1,T2,T3,T4,T5,T6,TOut>(promise : Promise<Tuple6<T1,T2,T3,T4,T5,T6>>, success : T1 -> T2 -> T3 -> T4 -> T5 -> T6 -> TOut) : Promise<TOut>
-    return promise.mapSuccess(function(t)
+    return promise.map(function(t)
       return success(t._0, t._1, t._2, t._3, t._4, t._5)
     );
 
@@ -301,12 +322,12 @@ class PromiseTuple5 {
   }
 
   public static function mapTuplePromise<T1,T2,T3,T4,T5,TOut>(promise : Promise<Tuple5<T1,T2,T3,T4,T5>>, success : T1 -> T2 -> T3 -> T4 -> T5 -> Promise<TOut>) : Promise<TOut>
-    return promise.mapSuccessPromise(function(t)
+    return promise.flatMap(function(t)
       return success(t._0, t._1, t._2, t._3, t._4)
     );
 
   public static function mapTuple<T1,T2,T3,T4,T5,TOut>(promise : Promise<Tuple5<T1,T2,T3,T4,T5>>, success : T1 -> T2 -> T3 -> T4 -> T5 -> TOut) : Promise<TOut>
-    return promise.mapSuccess(function(t)
+    return promise.map(function(t)
       return success(t._0, t._1, t._2, t._3, t._4)
     );
 
@@ -328,12 +349,12 @@ class PromiseTuple4 {
   }
 
   public static function mapTuplePromise<T1,T2,T3,T4,TOut>(promise : Promise<Tuple4<T1,T2,T3,T4>>, success : T1 -> T2 -> T3 -> T4 -> Promise<TOut>) : Promise<TOut>
-    return promise.mapSuccessPromise(function(t)
+    return promise.flatMap(function(t)
       return success(t._0, t._1, t._2, t._3)
     );
 
   public static function mapTuple<T1,T2,T3,T4,TOut>(promise : Promise<Tuple4<T1,T2,T3,T4>>, success : T1 -> T2 -> T3 -> T4 -> TOut) : Promise<TOut>
-    return promise.mapSuccess(function(t)
+    return promise.map(function(t)
       return success(t._0, t._1, t._2, t._3)
     );
 
@@ -355,12 +376,12 @@ class PromiseTuple3 {
   }
 
   public static function mapTuplePromise<T1,T2,T3,TOut>(promise : Promise<Tuple3<T1,T2,T3>>, success : T1 -> T2 -> T3 -> Promise<TOut>) : Promise<TOut>
-    return promise.mapSuccessPromise(function(t)
+    return promise.flatMap(function(t)
       return success(t._0, t._1, t._2)
     );
 
   public static function mapTuple<T1,T2,T3,TOut>(promise : Promise<Tuple3<T1,T2,T3>>, success : T1 -> T2 -> T3 -> TOut) : Promise<TOut>
-    return promise.mapSuccess(function(t)
+    return promise.map(function(t)
       return success(t._0, t._1, t._2)
     );
 
@@ -382,12 +403,12 @@ class PromiseTuple2 {
   }
 
   public static function mapTuplePromise<T1,T2,TOut>(promise : Promise<Tuple2<T1,T2>>, success : T1 -> T2 -> Promise<TOut>) : Promise<TOut>
-    return promise.mapSuccessPromise(function(t)
+    return promise.flatMap(function(t)
       return success(t._0, t._1)
     );
 
   public static function mapTuple<T1,T2,TOut>(promise : Promise<Tuple2<T1,T2>>, success : T1 -> T2 -> TOut) : Promise<TOut>
-    return promise.mapSuccess(function(t)
+    return promise.map(function(t)
       return success(t._0, t._1)
     );
 

--- a/test/thx/promise/TestPromise.hx
+++ b/test/thx/promise/TestPromise.hx
@@ -70,7 +70,7 @@ class TestPromise {
 
   public function testMapSuccessWithValue() {
     var done = Assert.createAsync();
-    Promise.value(1).mapSuccessPromise(function(v) {
+    Promise.value(1).flatMap(function(v) {
       return Promise.value(v * 2);
     }).success(function(v) {
       Assert.equals(2, v);
@@ -81,7 +81,7 @@ class TestPromise {
   public function testMapSuccessWithFailure() {
     var done = Assert.createAsync(),
         err = new Error("error");
-    Promise.error(err).mapSuccessPromise(function(v) {
+    Promise.error(err).flatMap(function(v) {
       Assert.fail("should never touch this");
       return Promise.value(v * 2);
     }).failure(function(e) {
@@ -155,7 +155,7 @@ class TestPromise {
       });
   }
 
-  /* Failing afterAll test preserved for future reference - see deprecation warning in Promise.afterAll */
+  /* Failing afterAll test preserved for future reference - see deprecation warning in Promise.afterAll 
   public function testAfterAllFailure2() {
     var done = Assert.createAsync();
     Promise.afterAll([res(), res(), rej()])
@@ -393,7 +393,7 @@ class TestPromise {
       Promise.error(err),
       Promise.error(err)
     ])
-    .mapSuccessPromise(function(v) {
+    .flatMap(function(v) {
       Assert.fail("should never happen");
       return Promise.value(new Tuple2(1, 2));
     })
@@ -410,7 +410,7 @@ class TestPromise {
   public function testMapSuccessFailure() {
     var done = Assert.createAsync();
     Promise.nil
-      .mapSuccess(function(_) return throw "NOOO!")
+      .map(function(_) return throw "NOOO!")
       .success(function(_) Assert.fail("should never succeed"))
       .failure(function(e) Assert.stringContains("NOOO!", e.toString()))
       .always(done);


### PR DESCRIPTION
This extends the cleanup from #9. 
