### PR TITLE
Deprecate Promise.all in favor of Promise.sequence.

### DIFF
--- a/src/thx/promise/Promise.hx
+++ b/src/thx/promise/Promise.hx
@@ -72,7 +72,7 @@ abstract Promise<T>(Future<Result<T, Error>>) to Future<Result<T, Error>> {
   }
 
   @:deprecated("Use Promise.sequence instead.")
-  public static function sequenceAll<T>(arr : Array<Promise<T>>) : Promise<Array<T>>
+  public static function allSequence<T>(arr : Array<Promise<T>>) : Promise<Array<T>>
     return sequence(arr);
 
   public static function create<T>(callback : (T -> Void) -> (Error -> Void) -> Void) : Promise<T>

--- a/src/thx/promise/PromiseExtensions.hx
+++ b/src/thx/promise/PromiseExtensions.hx
@@ -1,0 +1,13 @@
+package thx.promise;
+
+using thx.Arrays;
+
+class PromiseExtensions {
+  public static function traverse<A, B>(arr : Array<A>, f: A -> Promise<B>): Promise<Array<B>> {
+    return Promise.allSequence(arr.map(f));
+  }
+
+  public static function parTraverse<A, B>(arr: Array<A>, f: A -> Promise<B>): Promise<Array<B>> {
+    return Promise.all(arr.map(f));
+  }
+}

--- a/src/thx/promise/PromiseExtensions.hx
+++ b/src/thx/promise/PromiseExtensions.hx
@@ -2,12 +2,8 @@ package thx.promise;
 
 using thx.Arrays;
 
-class PromiseExtensions {
+class PromiseArrayExtensions {
   public static function traverse<A, B>(arr : Array<A>, f: A -> Promise<B>): Promise<Array<B>> {
-    return Promise.allSequence(arr.map(f));
-  }
-
-  public static function parTraverse<A, B>(arr: Array<A>, f: A -> Promise<B>): Promise<Array<B>> {
-    return Promise.all(arr.map(f));
+    return Promise.sequence(arr.map(f));
   }
 }

--- a/test/thx/promise/TestPromise.hx
+++ b/test/thx/promise/TestPromise.hx
@@ -92,7 +92,7 @@ class TestPromise {
 
   public function testAllSuccess() {
     var done = Assert.createAsync();
-    Promise.all([
+    Promise.sequence([
       Promise.value(1),
       Promise.value(2)
     ]).success(function(arr) {
@@ -104,7 +104,7 @@ class TestPromise {
   public function testAllFailure1() {
     var done = Assert.createAsync(),
         err  = new Error("error");
-    Promise.all([
+    Promise.sequence([
       Promise.value(1),
       Promise.error(err)
     ])
@@ -119,7 +119,7 @@ class TestPromise {
 
   public function testAllFailure2() {
     var done = Assert.createAsync();
-    Promise.all([res(), res(), rej()])
+    Promise.sequence([res(), res(), rej()])
     .success(function(arr) {
       Assert.fail("should never happen");
     })
@@ -388,7 +388,7 @@ class TestPromise {
   public function testAllMapToTupleFailure() {
     var done = Assert.createAsync(),
         err  = new Error("error");
-    Promise.all([
+    Promise.sequence([
       Promise.error(err),
       Promise.error(err)
     ])


### PR DESCRIPTION
Since Promise values begin evaluation eagerly, there is no semantic or evaluative difference between Promise.sequence and Promise.all.
