### PR TITLE
Add array traversal to PromiseRExtensions

### DIFF
--- a/src/thx/promise/PromiseR.hx
+++ b/src/thx/promise/PromiseR.hx
@@ -1,6 +1,7 @@
 package thx.promise;
 
 import thx.promise.Promise;
+import thx.Functions.identity;
 using thx.Functions;
 
 /**
@@ -35,11 +36,5 @@ abstract PromiseR<R, A>(R -> Promise<A>) from R -> Promise<A> {
 
   public function parWith<B, C>(that: PromiseR<R, B>, f: A -> B -> C): PromiseR<R, C> {
     return function(r: R) return Promises.par(f, run(r), that.run(r));
-  }
-}
-
-class PromiseRExtensions {
-  public static function liftR<R, A>(p: Promise<A>): PromiseR<R, A> {
-    return (function(r: R) return p);
   }
 }

--- a/src/thx/promise/PromiseR.hx
+++ b/src/thx/promise/PromiseR.hx
@@ -34,6 +34,14 @@ abstract PromiseR<R, A>(R -> Promise<A>) from R -> Promise<A> {
     }
   }
 
+  public function bindPromise<B>(f: A -> Promise<B>): PromiseR<R, B> {
+    return flatMap(
+      function(a: A) {
+        return ((function(r: R) return f(a)) : PromiseR<R, B>);
+      }
+    );
+  }
+
   public function parWith<B, C>(that: PromiseR<R, B>, f: A -> B -> C): PromiseR<R, C> {
     return function(r: R) return Promises.par(f, run(r), that.run(r));
   }

--- a/src/thx/promise/PromiseRExtensions.hx
+++ b/src/thx/promise/PromiseRExtensions.hx
@@ -1,0 +1,22 @@
+package thx.promise;
+
+import thx.Functions.identity;
+using thx.promise.PromiseExtensions;
+
+class PromiseRExtensions {
+  public static function liftR<R, A>(p: Promise<A>): PromiseR<R, A> {
+    return (function(r: R) return p);
+  }
+
+  public static function join<R, A>(p: PromiseR<R,PromiseR<R, A>>): PromiseR<R, A> {
+    return p.flatMap(identity);
+  }
+}
+
+class PromiseRArrayExtensions {
+  public static function traverse<R, A, B>(arr : Array<A>, f: A -> PromiseR<R, B>): PromiseR<R, Array<B>> {
+    return PromiseR.ask().flatMap(
+      function(r: R) return PromiseRExtensions.liftR(arr.traverse(function(a: A) return f(a).run(r)))
+    );
+  }
+}

--- a/src/thx/promise/PromiseRExtensions.hx
+++ b/src/thx/promise/PromiseRExtensions.hx
@@ -4,11 +4,12 @@ import thx.Functions.identity;
 using thx.promise.PromiseExtensions;
 
 class PromiseRExtensions {
-  public static function liftR<R, A>(p: Promise<A>): PromiseR<R, A> {
+  public static inline function liftR<R, A>(p: Promise<A>): PromiseR<R, A> {
     return (function(r: R) return p);
   }
 
-  public static function join<R, A>(p: PromiseR<R,PromiseR<R, A>>): PromiseR<R, A> {
+
+  public static inline function join<R, A>(p: PromiseR<R,PromiseR<R, A>>): PromiseR<R, A> {
     return p.flatMap(identity);
   }
 }

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -9,6 +9,7 @@ class TestAll {
     runner.addCase(new thx.promise.TestPromise());
     runner.addCase(new thx.promise.TestPromiseR());
     runner.addCase(new thx.promise.TestPromiseExtensions());
+    runner.addCase(new thx.promise.TestPromiseRExtensions());
     runner.addCase(new thx.promise.TestTryPromise());
     Report.create(runner);
     runner.run();

--- a/test/thx/promise/TestPromiseRExtensions.hx
+++ b/test/thx/promise/TestPromiseRExtensions.hx
@@ -1,0 +1,22 @@
+package thx.promise;
+
+import utest.Assert;
+using thx.promise.PromiseRExtensions;
+
+class TestPromiseRExtensions {
+  public function new() {}
+
+  public function testTraverse() {
+    var done = Assert.createAsync();
+    [1, 1, 1].traverse(
+      function(i: Int) return {
+        PromiseR.ask().map(function(j: Int) return i + j);
+      }
+    ).run(2).success(
+      function(xs) {
+        Assert.same([3, 3, 3], xs);
+        done();
+      }
+    );
+  }
+}


### PR DESCRIPTION
Lament that this code has to be reimplemented over, and over, and over.
