### PR TITLE
Change 'success' and 'failure' to 'successR' and 'failureR'

### DIFF
--- a/src/thx/promise/PromiseR.hx
+++ b/src/thx/promise/PromiseR.hx
@@ -57,11 +57,11 @@ abstract PromiseR<R, A>(R -> Promise<A>) from R -> Promise<A> {
     return function(r: R) return Promises.par(f, run(r), that.run(r));
   }
 
-  public function success(effect: A -> Void): PromiseR<R, A> {
+  public function successR(effect: A -> Void): PromiseR<R, A> {
     return function(r: R) return run(r).success(effect);
   }
 
-  public function failure(effect: Error -> Void): PromiseR<R, A> {
+  public function failureR(effect: Error -> Void): PromiseR<R, A> {
     return function(r: R) return run(r).failure(effect);
   }
 


### PR DESCRIPTION
Since 'success' and 'failure' are commonly used to run side
effects, they are hazardous because anything that is not checking
the result type will no longer have effects performed unless
the PromiseR is explicitly run.
