### PR TITLE
Add PromiseRF type.

### DIFF
--- a/src/thx/promise/PromiseRF.hx
+++ b/src/thx/promise/PromiseRF.hx
@@ -3,6 +3,8 @@ package thx.promise;
 import thx.Either;
 import thx.Functions.identity;
 import thx.Nil;
+import thx.Semigroup;
+import thx.Validation.*;
 import thx.fp.Functions.const;
 import thx.promise.Promise;
 using thx.Eithers;
@@ -12,7 +14,7 @@ using thx.Functions;
  * The ReaderT monad transformer specialized to Promise,
  * with the capability to capture custom errors.
  */
-abstract PromiseRF<R, E, A>(PromiseR<R, Either<E, A>>) from R -> Promise<Either<E, A>> {
+abstract PromiseRF<R, E, A>(PromiseR<R, Either<E, A>>) from PromiseR<R, Either<E, A>> {
   public static function pure<R, E, A>(a: A): PromiseRF<R, E, A> {
     return PromiseR.pure(Right(a)).run;
   }
@@ -26,7 +28,16 @@ abstract PromiseRF<R, E, A>(PromiseR<R, Either<E, A>>) from R -> Promise<Either<
   }
 
   public static function ask<R, E>(): PromiseRF<R, E, R> {
-    return function(x: R) return Promise.value(Right(x));
+    return PromiseR.ask().map(Right);
+  }
+
+  public static function value<E, A>(e: Either<E, A>) {
+    return PromiseR.pure(e);
+  }
+
+  @:from
+  public function new(f: R -> Promise<Either<E, A>>) {
+    this = f;
   }
 
   public inline function run(r: R): Promise<Either<E, A>> {
@@ -90,5 +101,51 @@ abstract PromiseRF<R, E, A>(PromiseR<R, Either<E, A>>) from R -> Promise<Either<
   public function nil(): PromiseRF<R, E, Nil> {
     return flatMap(const(PromiseRF.pure(Nil.nil)));
   }
+
+  /**
+   * Applicative composition with fail-on-first-error semantics
+   */
+  public static function liftA2<R, E, A, B, C>(f: A -> B -> C, pa: PromiseRF<R, E, A>, pb: PromiseRF<R, E, B>): PromiseRF<R, E, C> {
+    return pa.map(f.curry()).flatMap(pb.map);
+  }
+
+  /**
+   * Applicative composition with accumulate-errors semantics
+   */
+  public static function par2<R, E, A, B, C>(f: A -> B -> C, pa: PromiseRF<R, E, A>, pb: PromiseRF<R, E, B>, s: Semigroup<E>): PromiseRF<R, E, C> {
+    return function(r: R) {
+      return Promises.par(
+        function(ea: Either<E, A>, eb: Either<E, B>): Either<E, C> {
+          return val2(f, ea.toValidation(), eb.toValidation(), s).either;
+        },
+        pa.run(r), 
+        pb.run(r)
+      );
+    }
+  }
+
+  public static function par3<R, E, A, B, C, D>(
+      f: A -> B -> C -> D, p1 : PromiseRF<R, E, A>, p2 : PromiseRF<R, E, B>, p3 : PromiseRF<R, E, C>, s: Semigroup<E>) : PromiseRF<R, E, D>
+    return par2(function(f, g) return f(g), par2(f.curry(), p1, p2, s), p3, s);
+
+  public static function par4<R, E, A, B, C, D, F>(
+      f: A -> B -> C -> D -> F, p1 : PromiseRF<R, E, A>, p2 : PromiseRF<R, E, B>, p3 : PromiseRF<R, E, C>, 
+      p4 : PromiseRF<R, E, D>, s: Semigroup<E>) : PromiseRF<R, E, F>
+    return par2(function(f, g) return f(g), par3(f.curry(), p1, p2, p3, s), p4, s);
+
+  public static function par5<R, E, A, B, C, D, F, G>(
+      f: A -> B -> C -> D -> F -> G, p1 : PromiseRF<R, E, A>, p2 : PromiseRF<R, E, B>, p3 : PromiseRF<R, E, C>, 
+      p4 : PromiseRF<R, E, D>, p5: PromiseRF<R, E, F>, s: Semigroup<E>):PromiseRF<R, E, G>
+    return par2(function(f, g) return f(g), par4(f.curry(), p1, p2, p3, p4, s), p5, s);
+
+  public static function par6<R, E, A, B, C, D, F, G, H>(
+      f: A -> B -> C -> D -> F -> G -> H, p1 : PromiseRF<R, E, A>, p2 : PromiseRF<R, E, B>, p3 : PromiseRF<R, E, C>, 
+      p4 : PromiseRF<R, E, D>, p5: PromiseRF<R, E, F>, p6: PromiseRF<R, E, G>, s: Semigroup<E>): PromiseRF<R, E, H>
+    return par2(function(f, g) return f(g), par5(f.curry(), p1, p2, p3, p4, p5, s), p6, s);
+
+  public static function par7<R, E, A, B, C, D, F, G, H, I>(
+      f: A -> B -> C -> D -> F -> G -> H -> I, p1 : PromiseRF<R, E, A>, p2 : PromiseRF<R, E, B>, p3 : PromiseRF<R, E, C>, 
+      p4 : PromiseRF<R, E, D>, p5: PromiseRF<R, E, F>, p6: PromiseRF<R, E, G>, p7: PromiseRF<R, E, H>, s: Semigroup<E>): PromiseRF<R, E, I>
+    return par2(function(f, g) return f(g), par6(f.curry(), p1, p2, p3, p4, p5, p6, s), p7, s);
 }
 

--- a/src/thx/promise/PromiseRF.hx
+++ b/src/thx/promise/PromiseRF.hx
@@ -1,0 +1,94 @@
+package thx.promise;
+
+import thx.Either;
+import thx.Functions.identity;
+import thx.Nil;
+import thx.fp.Functions.const;
+import thx.promise.Promise;
+using thx.Eithers;
+using thx.Functions;
+
+/**
+ * The ReaderT monad transformer specialized to Promise,
+ * with the capability to capture custom errors.
+ */
+abstract PromiseRF<R, E, A>(PromiseR<R, Either<E, A>>) from R -> Promise<Either<E, A>> {
+  public static function pure<R, E, A>(a: A): PromiseRF<R, E, A> {
+    return PromiseR.pure(Right(a)).run;
+  }
+
+  public static function fail<R, E, A>(e: E): PromiseRF<R, E, A> {
+    return PromiseR.pure(Left(e)).run;
+  }
+
+  public static function die<R, E, A>(err : Error) : PromiseRF<R, E, A> {
+    return PromiseR.error(err).run;
+  }
+
+  public static function ask<R, E>(): PromiseRF<R, E, R> {
+    return function(x: R) return Promise.value(Right(x));
+  }
+
+  public inline function run(r: R): Promise<Either<E, A>> {
+    return this.run(r);
+  }
+
+  public function map<B>(f: A -> B): PromiseRF<R, E, B> {
+    return flatMap(pure.compose(f));
+  }
+
+  public function ap<B>(r: PromiseRF<R, E, A -> B>): PromiseRF<R, E, B> {
+    return flatMap(function(a: A) return r.map.fn(_(a)));
+  }
+
+  public function flatMap<B>(f: A -> PromiseRF<R, E, B>): PromiseRF<R, E, B> {
+    return function(r: R) {
+      return run(r).flatMap(
+        function(ea: Either<E, A>) return switch ea {
+          case Left(e):  Promise.value(Left(e));
+          case Right(a): f(a).run(r);
+        }
+      );
+    }
+  }
+
+  @:op(P1 >> P2)
+  public function then<B>(p: PromiseRF<R, E, B>): PromiseRF<R, E, B> {
+    return flatMap(const(p));
+  }
+
+  public function bindPromise<B>(f: A -> Promise<B>): PromiseRF<R, E, B> {
+    return flatMap(
+      function(a: A): PromiseRF<R, E, B> {
+        return const(f(a).map(Right));
+      }
+    );
+  }
+
+  public function successR(effect: A -> Void): PromiseRF<R, E, A> {
+    return function(r: R) return run(r).success.fn(_.each(effect));
+  }
+
+  public function failureR(effect: Error -> Void): PromiseRF<R, E, A> {
+    return function(r: R) return run(r).failure(effect);
+  }
+
+  public function recover(f: Error -> PromiseRF<R, E, A>): PromiseRF<R, E, A> {
+    return function(r: R) return run(r).recover(
+      function(err: Error) return f(err).run(r)
+    );
+  }
+
+  public function contramap<R0>(f: R0 -> R): PromiseRF<R0, E, A> {
+    return this.run.compose(f);
+  }
+
+  public function local<R0>(f: R -> R0, p: PromiseRF<R0, E, A>): PromiseRF<R, E, A> {
+    return function(r: R) return p.run(f(r));
+  }
+
+  public function nil(): PromiseRF<R, E, Nil> {
+    return flatMap(const(PromiseRF.pure(Nil.nil)));
+  }
+}
+

--- a/src/thx/promise/PromiseRFExtensions.hx
+++ b/src/thx/promise/PromiseRFExtensions.hx
@@ -16,18 +16,6 @@ class PromiseRFExtensions {
   public static inline function liftRF<R, E, A>(p: Promise<A>): PromiseRF<R, E, A> {
     return (function(r: R) return p.map(Right));
   }
-
-  public static function zipWith<R, E, A, B, C>(pa: PromiseRF<R, E, A>, pb: PromiseRF<R, E, B>, f: A -> B -> C, s: Semigroup<E>): PromiseRF<R, E, C> {
-    return function(r: R) {
-      return Promises.par(
-        function(ea: Either<E, A>, eb: Either<E, B>): Either<E, C> {
-          return val2(f, ea.toValidation(), eb.toValidation(), s).either;
-        },
-        pa.run(r), 
-        pb.run(r)
-      );
-    }
-  }
 }
 
 class PromiseRFArrayExtensions {

--- a/src/thx/promise/PromiseRFExtensions.hx
+++ b/src/thx/promise/PromiseRFExtensions.hx
@@ -1,0 +1,46 @@
+package thx.promise;
+
+import thx.Either;
+import thx.Functions.identity;
+import thx.Semigroup;
+import thx.Validation;
+import thx.Validation.*;
+using thx.Eithers;
+using thx.Functions;
+using thx.Arrays;
+
+import thx.promise.Promise;
+using thx.promise.PromiseExtensions;
+
+class PromiseRFExtensions {
+  public static inline function liftRF<R, E, A>(p: Promise<A>): PromiseRF<R, E, A> {
+    return (function(r: R) return p.map(Right));
+  }
+
+  public static function zipWith<R, E, A, B, C>(pa: PromiseRF<R, E, A>, pb: PromiseRF<R, E, B>, f: A -> B -> C, s: Semigroup<E>): PromiseRF<R, E, C> {
+    return function(r: R) {
+      return Promises.par(
+        function(ea: Either<E, A>, eb: Either<E, B>): Either<E, C> {
+          return val2(f, ea.toValidation(), eb.toValidation(), s).either;
+        },
+        pa.run(r), 
+        pb.run(r)
+      );
+    }
+  }
+}
+
+class PromiseRFArrayExtensions {
+  public static function traverse<R, E, A, B>(arr : ReadonlyArray<A>, f: A -> PromiseRF<R, E, B>): PromiseRF<R, E, Array<B>> {
+    return PromiseRF.ask().flatMap(
+      function(r: R): PromiseRF<R, E, Array<B>> {
+        return function(r: R): Promise<Either<E, Array<B>>> {
+          var promiseEithers: Promise<Array<Either<E, B>>> = arr.traverse(function(a: A) return f(a).run(r));
+          return promiseEithers.map(
+            function(xs: Array<Either<E, B>>): Either<E, Array<B>> return xs.traverseEither(identity)
+          );
+        }
+      }
+    );
+  }
+}

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -8,8 +8,10 @@ class TestAll {
     runner.addCase(new thx.promise.TestFuture());
     runner.addCase(new thx.promise.TestPromise());
     runner.addCase(new thx.promise.TestPromiseR());
+    runner.addCase(new thx.promise.TestPromiseRF());
     runner.addCase(new thx.promise.TestPromiseExtensions());
     runner.addCase(new thx.promise.TestPromiseRExtensions());
+    runner.addCase(new thx.promise.TestPromiseRFExtensions());
     runner.addCase(new thx.promise.TestTryPromise());
     Report.create(runner);
     runner.run();

--- a/test/thx/promise/TestPromiseRF.hx
+++ b/test/thx/promise/TestPromiseRF.hx
@@ -1,0 +1,75 @@
+package thx.promise;
+
+import utest.Assert;
+
+import thx.Either;
+import thx.Error;
+using thx.Arrays;
+using thx.Functions;
+using thx.Tuple;
+
+class TestPromiseRF {
+  public function new() {}
+
+  public function testMap_Success() {
+    var done = Assert.createAsync();
+    return PromiseRF.pure(2)
+      .map.fn(_ * 4)
+      .run("hi")
+      .success(function(v) {
+        Assert.same(Right(8), v);
+        done();
+      });
+  }
+
+  public function testMap_Failure() {
+    var done = Assert.createAsync();
+    return PromiseRF.die(new Error('die'))
+      .map.fn(_ * 4)
+      .run("hi")
+      .failure(function(e) {
+        Assert.same("die", e.message);
+        done();
+      });
+  }
+
+  public function testFlatMap() {
+    var done = Assert.createAsync();
+    var action: PromiseRF<Int, Nil, Int> = PromiseRF.pure(2).flatMap(
+      function(v) return PromiseRF.ask().flatMap(
+        function(r) return PromiseRF.pure(r * v * 2)
+      )
+    );
+
+    action.run(2).success(function(v) {
+      Assert.same(Right(8), v);
+      done();
+    });
+  }
+
+
+  public function testNil_Success() {
+    var done = Assert.createAsync();
+    PromiseRF.pure(1)
+      .nil()
+      .run("hi")
+      .success(function(v : Either<Nil, Nil>) {
+        Assert.same(Right(Nil.nil), v);
+        done();
+      });
+  }
+
+  public function testNil_Failure() {
+    var done = Assert.createAsync();
+    PromiseRF.ask().bindPromise(function(v : String) {
+      return Promise.fail('$v guy');
+    })
+    .nil()
+    .run("hi")
+    .failure(function(e) {
+      Assert.same("hi guy", e.message);
+      done();
+    });
+  }
+}
+

--- a/test/thx/promise/TestPromiseRFExtensions.hx
+++ b/test/thx/promise/TestPromiseRFExtensions.hx
@@ -1,0 +1,25 @@
+package thx.promise;
+
+import utest.Assert;
+
+import thx.Either;
+using thx.promise.PromiseRFExtensions;
+
+class TestPromiseRFExtensions {
+  public function new() {}
+
+  public function testTraverse() {
+    var done = Assert.createAsync();
+    [1, 1, 1].traverse(
+      function(i: Int) return {
+        PromiseRF.ask().map(function(j: Int) return i + j);
+      }
+    ).run(2).success(
+      function(xs) {
+        Assert.same(Right([3, 3, 3]), xs);
+        done();
+      }
+    );
+  }
+}
+


### PR DESCRIPTION
This is PromiseR with added functionality for tracking errors
in a typed fashion, rather than just pushing everything into
thx.Error and using unchecked error handlers.

The rationale for this change is that it is difficult to distinguish
between fatal errors that should be opaque to the user, and errors
which the end-user can be reasonably expected to correct. For the
former category, the only reasonable behavior may be to retry
the same request; for the latter, the user should modify their
calling behavior in order to ensure a correct result. While
PromiseR is adequate for the former, it does not communicate the
latter case clearly in its type. In any real system, we need both
varieties of error handling, hence this commit.